### PR TITLE
New method of displaying the full screen image, rather than invoking the browser's API

### DIFF
--- a/src/components/MDXComponents/ImageZoomable.tsx
+++ b/src/components/MDXComponents/ImageZoomable.tsx
@@ -45,7 +45,8 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
         <Box className="zoom-overlay" style={{backgroundColor:"rgba(0,0,0,0.7)",zIndex:10000,position:"fixed",top:0,bottom:0,left:0,right:0}} />
         
         );
-        ReactDOM.render(overlay, document.getElementsByClassName("zoom-overlay")[0]);
+        ReactDOM.render(overlay, ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0]);
+        console.log(ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0]);
         //append large image
       }
     }

--- a/src/components/MDXComponents/ImageZoomable.tsx
+++ b/src/components/MDXComponents/ImageZoomable.tsx
@@ -54,11 +54,9 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
         
         imagebox.style.position = "fixed";
         imagebox.style.zIndex = "99999";
-        imagebox.style.top = "50px";
-        imagebox.style.left = "50px";
-        imagebox.style.bottom = "50px";
-        imagebox.style.right = "50px";
-        
+        imagebox.style.left = "50%";
+        imagebox.style.top = "50%";
+        imagebox.style.transform = "translate(-50%,-50%) scale(1.8)";
 
         ImageZoomableRef.current.style.position = "fixed";
         ImageZoomableRef.current.style.zIndex = "10001";/*

--- a/src/components/MDXComponents/ImageZoomable.tsx
+++ b/src/components/MDXComponents/ImageZoomable.tsx
@@ -31,26 +31,20 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
   const fullscreen = () => {
     if (ImageZoomableRef.current) {
       if (isFullscreen) {
-        console.log("gonna exit fullscreen mode")
         setIsFullScreen(false);
-        let ele = ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0] as HTMLElement;
-        ele.style.opacity = "0";
-        ele.style.transition = "opacity .15s ease-in-out";
+        let ele_overlay = ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0] as HTMLElement;
+        ele_overlay.style.opacity = "0";
+        ele_overlay.style.transition = "opacity .15s ease-in-out";
 
-        ImageZoomableRef.current.parentElement!.style.height = "unset"
+        ImageZoomableRef.current.parentElement!.style.height = "unset";
         ImageZoomableRef.current.parentElement!.style.border = "none";
 
-        console.log("取消全屏")
-
-        console.log(ele)
       } else {
 
         setIsFullScreen(true);
-        let ele = ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0] as HTMLElement;
-        console.log("设置全屏")
-        ele.style.opacity = "1";
-        ele.style.transition = "opacity .3s ease-in-out";
-        console.log(ele)
+        let ele_overlay = ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0] as HTMLElement;
+        ele_overlay.style.opacity = "1";
+        ele_overlay.style.transition = "opacity .3s ease-in-out";
 
         ImageZoomableRef.current.parentElement!.style.height = "50px";
         ImageZoomableRef.current.parentElement!.style.border = "1px grey dashed";

--- a/src/components/MDXComponents/ImageZoomable.tsx
+++ b/src/components/MDXComponents/ImageZoomable.tsx
@@ -1,4 +1,4 @@
-import { Box, Fade, IconButton, Tooltip } from "@mui/material";
+import { Box, Fade, IconButton} from "@mui/material";
 
 import ZoomInIcon from "@mui/icons-material/ZoomIn";
 import ZoomOutIcon from "@mui/icons-material/ZoomOut";
@@ -10,9 +10,7 @@ import React, {
     PropsWithChildren,
     useRef,
     useState,
-    useEffect,
   } from "react";
-import ReactDOM from "react-dom";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
 type ImageZoomableWrapperProps = PropsWithChildren<{
@@ -33,7 +31,8 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
   const fullscreen = () => {
     if (ImageZoomableRef.current) {
       if (isFullscreen) {
-        document.exitFullscreen();
+        console.log("gonna exit fullscreen mode")
+        setIsFullScreen(false);
       } else {
         /*ImageZoomableRef.current.requestFullscreen()
           .catch((err) => {
@@ -41,83 +40,18 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
           });*/
         setIsFullScreen(true);
 
-        //append overlay(grey background)
-        const overlay = (
-          //<Box style={{position:"fixed",zIndex:"9999"}}>
-        <Box className="zoom-overlay" style={{backgroundColor:"rgba(0,0,0,0.7)",zIndex:99998,position:"fixed",top:0,bottom:0,left:0,right:0}} />
-        //</Box>
-        );
-
-        
-        ReactDOM.render(overlay, ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0]);
-        
-        const imagebox = ImageZoomableRef.current.getElementsByClassName("react-transform-wrapper")[0] as HTMLElement;
-        const buttongroupbox = ImageZoomableRef.current.getElementsByClassName("ZoomButtonGroup")[0] as HTMLElement;
-
-        imagebox.style.position = "fixed";
-        imagebox.style.zIndex = "99999";
-        imagebox.style.left = "50%";
-        imagebox.style.top = "50%";
-        imagebox.style.transform = "translate(-50%,-50%) scale(1.6)";
-
-        buttongroupbox.style.position = "fixed";
-        buttongroupbox.style.zIndex = "99999";
-        buttongroupbox.style.left = "50%";
-        buttongroupbox.style.top = "95%";
-        buttongroupbox.style.transform = "translate(-50%,-50%)";
-        //buttongroupbox.style.visibility = "visible";
-
-        ImageZoomableRef.current.style.position = "fixed";
-        ImageZoomableRef.current.style.zIndex = "10001";/*
-        ImageZoomableRef.current.style.top = "50px";
-        ImageZoomableRef.current.style.left = "50px";
-        ImageZoomableRef.current.style.bottom = "50px";
-        ImageZoomableRef.current.style.right = "50px";*/
-
-
-        console.log(ImageZoomableRef.current);
-        console.log(buttongroupbox)
-        //append large image
-
-
       }
     }
   }
-  /*
-  useEffect(() => {
-    window.onresize = () => {
-      setIsFullScreen((document.fullscreenElement != null) ? true: false);
-      if (document.fullscreenElement) {
 
-        // when entered fullscreen, set image position to flex-centered for better display
-        const ele = document.fullscreenElement as HTMLElement
-        ele.style.display = 'flex';
-        ele.style.alignItems = 'center';
-        ele.style.justifyContent = 'center';
-        ele.style.flexFlow = 'column-reverse';
-
-        // when entered fullscreen, unset 'position:absolute' zoom button group for better display
-        const ele2 = ele.querySelector(".ZoomButtonGroup") as HTMLElement;
-        ele2.style.position = 'unset';
-
-      } else {
-        if (ImageZoomableRef.current) {
-          
-          // exited fullscreen and back to normal position
-          ImageZoomableRef.current.style.display = 'block';
-
-          // exited fullscreen and restore 'position:absolute' of zoom button group
-          const ele2 = ImageZoomableRef.current.querySelector(".ZoomButtonGroup") as HTMLElement;
-          ele2.style.position = 'absolute';
-        }
-      }
-    }
-  })
-*/
   return (
     <Box
       className="ImageZoomableContainer"
       ref={ImageZoomableRef}
+      sx={{
+        position: (isFullscreen ? "fixed" : "inherit"),
+        zIndex: (isFullscreen ? "10001" : "inherit")
+      }}
       onMouseEnter={() => {
         contextCursor = "grab";
         setIsHovered(true);
@@ -157,34 +91,37 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
               <Box
                 className="ZoomButtonGroup"
                 sx={{
-                  position: 'absolute',
-                  float: 'left',
-                  zIndex: 99,
-                  backgroundColor: 'rgb(229,229,229)',
+                  position: (isFullscreen ? "fixed" : "absolute"),
+                  float: "left",
+                  zIndex: (isFullscreen ? 99999 : 99),
+                  backgroundColor: "rgb(229,229,229)",
                   borderRadius: 18,
-                  marginTop: '.5rem',
-                  marginLeft: '.5rem',
+                  marginTop: ".5rem",
+                  marginLeft: ".5rem",
+                  transform: (isFullscreen ? "translate(-50%,-50%)" : "inherit"),
+                  left: (isFullscreen ? "50%" : "inherit"),
+                  top: (isFullscreen ? "95%" : "inherit")
                 }}>
                 <IconButton
-                  aria-label='btn-zoomin'
+                  aria-label="btn-zoomin"
                   onClick={() => zoomIn()}
                 >
                   <ZoomInIcon fontSize={contextIconSize}/>
                 </IconButton>
                 <IconButton
-                  aria-label='btn-zoomout'
+                  aria-label="btn-zoomout"
                   onClick={() => zoomOut()}
                 >
                   <ZoomOutIcon fontSize={contextIconSize}/>
                 </IconButton>
                 <IconButton
-                  aria-label='btn-zoomreset'
+                  aria-label="btn-zoomreset"
                   onClick={() => resetTransform()}
                 >
                   <AutorenewIcon fontSize={contextIconSize}/>
                 </IconButton>
                 <IconButton
-                  aria-label= { isFullscreen ? ('btn-fullscreen-exit') : ('btn-fullscreen') } 
+                  aria-label= { isFullscreen ? "btn-fullscreen-exit" : "btn-fullscreen" } 
                   onClick={() => fullscreen()}
                 >
                   { isFullscreen ? (
@@ -194,13 +131,29 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
                 </IconButton>
               </Box>
             </Fade>
-            <TransformComponent contentStyle={{ cursor: contextCursor }}>
+            <TransformComponent
+              contentStyle={{ cursor: contextCursor }}
+              wrapperStyle={{
+                position: ( isFullscreen ? "fixed" : "inherit" ),
+                zIndex: ( isFullscreen ? "99999" : "inherit" ),
+                left: ( isFullscreen ? "50%" : "inherit" ),
+                top: ( isFullscreen ? "50%" : "inherit" ),
+                transform: ( isFullscreen ? "translate(-50%,-50%) scale(1.6)" : "inherit" )
+              }}>
               <img src={src} alt={alt}/>
             </TransformComponent>
           </React.Fragment>
         )}
       </TransformWrapper>
-      <Box className="zoom-overlay"/>
+      <Box
+        className="zoom-overlay"
+        sx={{
+          backgroundColor: (isFullscreen ? "rgba(0,0,0,0.7)" : "none"),
+          position: (isFullscreen ? "fixed" : "inherit"),
+          zIndex: (isFullscreen ? 99998 : "inherit"),
+          inset: (isFullscreen ? 0 : "inherit")
+        }}
+      />
     </Box>
   );
 };

--- a/src/components/MDXComponents/ImageZoomable.tsx
+++ b/src/components/MDXComponents/ImageZoomable.tsx
@@ -134,11 +134,12 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
             <TransformComponent
               contentStyle={{ cursor: contextCursor }}
               wrapperStyle={{
-                position: ( isFullscreen ? "fixed" : "inherit" ),
-                zIndex: ( isFullscreen ? "99999" : "inherit" ),
-                left: ( isFullscreen ? "50%" : "inherit" ),
-                top: ( isFullscreen ? "50%" : "inherit" ),
-                transform: ( isFullscreen ? "translate(-50%,-50%) scale(1.6)" : "inherit" )
+                position: (isFullscreen ? "fixed" : "inherit"),
+                zIndex: (isFullscreen ? "99999" : "inherit"),
+                left: (isFullscreen ? "50%" : "inherit"),
+                top: (isFullscreen ? "50%" : "inherit"),
+                transform: (isFullscreen ? "translate(-50%,-50%) scale(1.6)" : "inherit"),
+                transition: "transform .3s cubic-bezier(.2,0,.2,1)"
               }}>
               <img src={src} alt={alt}/>
             </TransformComponent>
@@ -148,10 +149,12 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
       <Box
         className="zoom-overlay"
         sx={{
-          backgroundColor: (isFullscreen ? "rgba(0,0,0,0.7)" : "none"),
+          backgroundColor: "rgba(0,0,0,0.7)",
+          opacity: (isFullscreen ? 1 : 0),
           position: (isFullscreen ? "fixed" : "inherit"),
           zIndex: (isFullscreen ? 99998 : "inherit"),
-          inset: (isFullscreen ? 0 : "inherit")
+          inset: (isFullscreen ? 0 : "inherit"),
+          transition: "opacity .3s",
         }}
       />
     </Box>

--- a/src/components/MDXComponents/ImageZoomable.tsx
+++ b/src/components/MDXComponents/ImageZoomable.tsx
@@ -34,26 +34,19 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
         console.log("gonna exit fullscreen mode")
         setIsFullScreen(false);
         let ele = ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0] as HTMLElement;
-        ele.style.backgroundColor = "rgba(0,0,0,0.7)";
         ele.style.opacity = "0";
-        ele.style.position = "fixed";
-        ele.style.zIndex = "99998";
-        ele.style.inset = "0";
-        ele.style.transition = "opacity 3s ease-in-out";
-        ele.style.pointerEvents = "none";
+        ele.style.transition = "opacity .15s ease-in-out";
+
         console.log("取消全屏")
 
         console.log(ele)
       } else {
-        /*ImageZoomableRef.current.requestFullscreen()
-          .catch((err) => {
-            console.error(`Error in enabling fullscreen mode: ${err.message}`);
-          });*/
+
         setIsFullScreen(true);
         let ele = ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0] as HTMLElement;
         console.log("设置全屏")
         ele.style.opacity = "1";
-
+        ele.style.transition = "opacity .3s ease-in-out";
         console.log(ele)
 
 
@@ -156,7 +149,7 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
                 left: (isFullscreen ? "50%" : "inherit"),
                 top: (isFullscreen ? "50%" : "inherit"),
                 transform: (isFullscreen ? "translate(-50%,-50%) scale(1.6)" : "inherit"),
-                //transition: "transform .3s cubic-bezier(.2,0,.2,1)"
+                transition: "transform .3s cubic-bezier(.2,0,.2,1)",
               }}>
               <img src={src} alt={alt}/>
             </TransformComponent>
@@ -167,11 +160,11 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
         className="zoom-overlay"
         sx={{
           backgroundColor: "rgba(0,0,0,0.7)",
-          opacity: (isFullscreen ? "1" : "0"),
-          position: (isFullscreen ? "fixed" : "inherit"),
-          zIndex: (isFullscreen ? "99998" : "inherit"),
-          inset: (isFullscreen ? "0" : "inherit"),
-          transition: "opacity 3s ease-in-out",
+          opacity: "0",
+          position: "fixed",
+          zIndex: "99998",
+          inset: "0",
+          pointerEvents: "none"
         }}
       />
     </Box>

--- a/src/components/MDXComponents/ImageZoomable.tsx
+++ b/src/components/MDXComponents/ImageZoomable.tsx
@@ -42,12 +42,36 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
 
         //append overlay(grey background)
         const overlay = (
-        <Box className="zoom-overlay" style={{backgroundColor:"rgba(0,0,0,0.7)",zIndex:10000,position:"fixed",top:0,bottom:0,left:0,right:0}} />
-        
+          //<Box style={{position:"fixed",zIndex:"9999"}}>
+        <Box className="zoom-overlay" style={{backgroundColor:"rgba(0,0,0,0.7)",zIndex:99998,position:"fixed",top:0,bottom:0,left:0,right:0}} />
+        //</Box>
         );
+
+        
         ReactDOM.render(overlay, ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0]);
-        console.log(ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0]);
+        
+        const imagebox = ImageZoomableRef.current.getElementsByClassName("react-transform-wrapper")[0] as HTMLElement;
+        
+        imagebox.style.position = "fixed";
+        imagebox.style.zIndex = "99999";
+        imagebox.style.top = "50px";
+        imagebox.style.left = "50px";
+        imagebox.style.bottom = "50px";
+        imagebox.style.right = "50px";
+        
+
+        ImageZoomableRef.current.style.position = "fixed";
+        ImageZoomableRef.current.style.zIndex = "10001";/*
+        ImageZoomableRef.current.style.top = "50px";
+        ImageZoomableRef.current.style.left = "50px";
+        ImageZoomableRef.current.style.bottom = "50px";
+        ImageZoomableRef.current.style.right = "50px";*/
+
+        console.log(ImageZoomableRef.current);
+        console.log(imagebox)
         //append large image
+
+
       }
     }
   }
@@ -111,7 +135,7 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
         }, 4000);
       }}
       >
-      <Box className="zoom-overlay"/>
+      
       <TransformWrapper
         initialScale={1}
         initialPositionX={0}
@@ -166,6 +190,7 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
           </React.Fragment>
         )}
       </TransformWrapper>
+      <Box className="zoom-overlay"/>
     </Box>
   );
 };

--- a/src/components/MDXComponents/ImageZoomable.tsx
+++ b/src/components/MDXComponents/ImageZoomable.tsx
@@ -39,6 +39,7 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
           .catch((err) => {
             console.error(`Error in enabling fullscreen mode: ${err.message}`);
           });*/
+        setIsFullScreen(true);
 
         //append overlay(grey background)
         const overlay = (
@@ -51,12 +52,20 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
         ReactDOM.render(overlay, ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0]);
         
         const imagebox = ImageZoomableRef.current.getElementsByClassName("react-transform-wrapper")[0] as HTMLElement;
-        
+        const buttongroupbox = ImageZoomableRef.current.getElementsByClassName("ZoomButtonGroup")[0] as HTMLElement;
+
         imagebox.style.position = "fixed";
         imagebox.style.zIndex = "99999";
         imagebox.style.left = "50%";
         imagebox.style.top = "50%";
-        imagebox.style.transform = "translate(-50%,-50%) scale(1.8)";
+        imagebox.style.transform = "translate(-50%,-50%) scale(1.6)";
+
+        buttongroupbox.style.position = "fixed";
+        buttongroupbox.style.zIndex = "99999";
+        buttongroupbox.style.left = "50%";
+        buttongroupbox.style.top = "95%";
+        buttongroupbox.style.transform = "translate(-50%,-50%)";
+        //buttongroupbox.style.visibility = "visible";
 
         ImageZoomableRef.current.style.position = "fixed";
         ImageZoomableRef.current.style.zIndex = "10001";/*
@@ -65,15 +74,16 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
         ImageZoomableRef.current.style.bottom = "50px";
         ImageZoomableRef.current.style.right = "50px";*/
 
+
         console.log(ImageZoomableRef.current);
-        console.log(imagebox)
+        console.log(buttongroupbox)
         //append large image
 
 
       }
     }
   }
-  
+  /*
   useEffect(() => {
     window.onresize = () => {
       setIsFullScreen((document.fullscreenElement != null) ? true: false);
@@ -103,7 +113,7 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
       }
     }
   })
-
+*/
   return (
     <Box
       className="ImageZoomableContainer"
@@ -113,7 +123,9 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
         setIsHovered(true);
       }}
       onMouseLeave={() => {
-        setIsHovered(false);
+        if (!isFullscreen) {
+          setIsHovered(false);
+        }
       }}
       onMouseDown={() => {
         setIsDragging(true);

--- a/src/components/MDXComponents/ImageZoomable.tsx
+++ b/src/components/MDXComponents/ImageZoomable.tsx
@@ -12,6 +12,7 @@ import React, {
     useState,
     useEffect,
   } from "react";
+import ReactDOM from "react-dom";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
 type ImageZoomableWrapperProps = PropsWithChildren<{
@@ -34,10 +35,18 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
       if (isFullscreen) {
         document.exitFullscreen();
       } else {
-        ImageZoomableRef.current.requestFullscreen()
+        /*ImageZoomableRef.current.requestFullscreen()
           .catch((err) => {
             console.error(`Error in enabling fullscreen mode: ${err.message}`);
-          });
+          });*/
+
+        //append overlay(grey background)
+        const overlay = (
+        <Box className="zoom-overlay" style={{backgroundColor:"rgba(0,0,0,0.7)",zIndex:10000,position:"fixed",top:0,bottom:0,left:0,right:0}} />
+        
+        );
+        ReactDOM.render(overlay, document.getElementsByClassName("zoom-overlay")[0]);
+        //append large image
       }
     }
   }
@@ -101,6 +110,7 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
         }, 4000);
       }}
       >
+      <Box className="zoom-overlay"/>
       <TransformWrapper
         initialScale={1}
         initialPositionX={0}

--- a/src/components/MDXComponents/ImageZoomable.tsx
+++ b/src/components/MDXComponents/ImageZoomable.tsx
@@ -33,12 +33,29 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
       if (isFullscreen) {
         console.log("gonna exit fullscreen mode")
         setIsFullScreen(false);
+        let ele = ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0] as HTMLElement;
+        ele.style.backgroundColor = "rgba(0,0,0,0.7)";
+        ele.style.opacity = "0";
+        ele.style.position = "fixed";
+        ele.style.zIndex = "99998";
+        ele.style.inset = "0";
+        ele.style.transition = "opacity 3s ease-in-out";
+        ele.style.pointerEvents = "none";
+        console.log("取消全屏")
+
+        console.log(ele)
       } else {
         /*ImageZoomableRef.current.requestFullscreen()
           .catch((err) => {
             console.error(`Error in enabling fullscreen mode: ${err.message}`);
           });*/
         setIsFullScreen(true);
+        let ele = ImageZoomableRef.current.getElementsByClassName("zoom-overlay")[0] as HTMLElement;
+        console.log("设置全屏")
+        ele.style.opacity = "1";
+
+        console.log(ele)
+
 
       }
     }
@@ -139,7 +156,7 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
                 left: (isFullscreen ? "50%" : "inherit"),
                 top: (isFullscreen ? "50%" : "inherit"),
                 transform: (isFullscreen ? "translate(-50%,-50%) scale(1.6)" : "inherit"),
-                transition: "transform .3s cubic-bezier(.2,0,.2,1)"
+                //transition: "transform .3s cubic-bezier(.2,0,.2,1)"
               }}>
               <img src={src} alt={alt}/>
             </TransformComponent>
@@ -150,11 +167,11 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
         className="zoom-overlay"
         sx={{
           backgroundColor: "rgba(0,0,0,0.7)",
-          opacity: (isFullscreen ? 1 : 0),
+          opacity: (isFullscreen ? "1" : "0"),
           position: (isFullscreen ? "fixed" : "inherit"),
-          zIndex: (isFullscreen ? 99998 : "inherit"),
-          inset: (isFullscreen ? 0 : "inherit"),
-          transition: "opacity .3s",
+          zIndex: (isFullscreen ? "99998" : "inherit"),
+          inset: (isFullscreen ? "0" : "inherit"),
+          transition: "opacity 3s ease-in-out",
         }}
       />
     </Box>

--- a/src/components/MDXComponents/ImageZoomable.tsx
+++ b/src/components/MDXComponents/ImageZoomable.tsx
@@ -37,6 +37,9 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
         ele.style.opacity = "0";
         ele.style.transition = "opacity .15s ease-in-out";
 
+        ImageZoomableRef.current.parentElement!.style.height = "unset"
+        ImageZoomableRef.current.parentElement!.style.border = "none";
+
         console.log("取消全屏")
 
         console.log(ele)
@@ -49,6 +52,8 @@ export const ImageZoomable: React.FC<ImageZoomableWrapperProps> = ({ src, alt })
         ele.style.transition = "opacity .3s ease-in-out";
         console.log(ele)
 
+        ImageZoomableRef.current.parentElement!.style.height = "50px";
+        ImageZoomableRef.current.parentElement!.style.border = "1px grey dashed";
 
       }
     }


### PR DESCRIPTION
Updated image full screen interface:

![image](https://github.com/curiousRay/website-docs/assets/24775856/6f937423-9961-41d3-8c79-a6d37d572674)
